### PR TITLE
feat: add kafka-exporter to snap

### DIFF
--- a/snap/local/exporter-wrapper.bash
+++ b/snap/local/exporter-wrapper.bash
@@ -33,5 +33,5 @@ args+=" --sasl.mechansim=scram-sha512"
 args+=" --sasl.username=exporter"
 args+=" --sasl.password=${PASSWORD}"
 
-"{SNAP}"/kafka_exporter "${args[@]}"
+"{SNAP}"/opt/kafka/kafka_exporter "${args[@]}"
 

--- a/snap/local/exporter-wrapper.bash
+++ b/snap/local/exporter-wrapper.bash
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -eu
+
+# TODO: create exporter.properties in charm
+# create exporteruser with read/describe ACLs
+PROPERTIES=$(cat "${SNAP_COMMON}"/exporter.properties)
+BOOTSTRAP_SERVERS=$(echo "${PROPERTIES}" | grep bootstrap.servers | sed 's/bootstrap\.servers=//g')
+SECURITY_PROTOCOL=$(echo "${PROPERTIES}" | grep security.protocol | sed 's/security\.protocol=//g')
+SASL_JAAS_CONFIG=$(echo $PROPERTIES | grep sasl.jaas.config | sed 's/sasl\.jaas\.config=//g')
+PASSWORD=$(echo $SASL_JAAS_CONFIG | grep -oP "password\=\"([a-zA-Z0-9]+)" | cut -d "\"" -f 2)
+
+for i in $(echo $BOOTSTRAP_SERVERS | tr "," "\n")
+do
+    args+=("--kafka.server=${i}")
+done
+
+if [ -n "$(echo "${SECURITY_PROTOCOL}" | grep "SSL")" ]
+then
+    args+=" --tls.enabled"
+fi
+
+args+=" --sasl.enabled"
+args+=" --sasl.mechansim=scram-sha512"
+args+=" --sasl.username=exporter"
+args+=" --sasl.password=${PASSWORD}"
+args+=" --tls.ca-file=${SNAP_COMMON}/ca.pem"
+args+=" --tls.cert-file=${SNAP_COMMON}/server.pem"
+args+=" --tls.key-file=${SNAP_COMMON}/server.key"
+
+"{SNAP}"/kafka_exporter "${args[@]}"
+

--- a/snap/local/exporter-wrapper.bash
+++ b/snap/local/exporter-wrapper.bash
@@ -16,15 +16,15 @@ done
 if [ -n "$(echo "${SECURITY_PROTOCOL}" | grep "SSL")" ]
 then
     args+=" --tls.enabled"
+    args+=" --tls.ca-file=${SNAP_COMMON}/ca.pem"
+    args+=" --tls.cert-file=${SNAP_COMMON}/server.pem"
+    args+=" --tls.key-file=${SNAP_COMMON}/server.key"
 fi
 
 args+=" --sasl.enabled"
 args+=" --sasl.mechansim=scram-sha512"
 args+=" --sasl.username=exporter"
 args+=" --sasl.password=${PASSWORD}"
-args+=" --tls.ca-file=${SNAP_COMMON}/ca.pem"
-args+=" --tls.cert-file=${SNAP_COMMON}/server.pem"
-args+=" --tls.key-file=${SNAP_COMMON}/server.key"
 
 "{SNAP}"/kafka_exporter "${args[@]}"
 

--- a/snap/local/exporter-wrapper.bash
+++ b/snap/local/exporter-wrapper.bash
@@ -2,6 +2,13 @@
 
 set -eu
 
+if [ ! -f "${SNAP_COMMON}"/exporter.properties ]
+then
+    echo "Missing exporter.properties from SNAP_COMMON"
+    exit 1
+fi
+
+
 PROPERTIES=$(cat "${SNAP_COMMON}"/exporter.properties)
 BOOTSTRAP_SERVERS=$(echo "${PROPERTIES}" | grep bootstrap.servers | sed 's/bootstrap\.servers=//g')
 SECURITY_PROTOCOL=$(echo "${PROPERTIES}" | grep security.protocol | sed 's/security\.protocol=//g')

--- a/snap/local/exporter-wrapper.bash
+++ b/snap/local/exporter-wrapper.bash
@@ -2,8 +2,6 @@
 
 set -eu
 
-# TODO: create exporter.properties in charm
-# create exporteruser with read/describe ACLs
 PROPERTIES=$(cat "${SNAP_COMMON}"/exporter.properties)
 BOOTSTRAP_SERVERS=$(echo "${PROPERTIES}" | grep bootstrap.servers | sed 's/bootstrap\.servers=//g')
 SECURITY_PROTOCOL=$(echo "${PROPERTIES}" | grep security.protocol | sed 's/security\.protocol=//g')

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -120,6 +120,9 @@ apps:
     plugs: [network, network-bind]
     environment:
       _wrapper_script: trogdor.sh
+  exporter:
+    command: opt/kafka/kafka_exporter
+    plugs: [network, network-bind, removable-media]
 
 parts:
   dependencies:
@@ -137,6 +140,12 @@ parts:
       archive="kafka_2.13-${SNAPCRAFT_PROJECT_VERSION}.tgz"
       curl -o "${archive}" "https://downloads.apache.org/kafka/${SNAPCRAFT_PROJECT_VERSION}/${archive}"
       mkdir -p $CRAFT_PART_INSTALL/opt/kafka
+      tar -xzvf "${archive}" -C "${CRAFT_PART_INSTALL}/opt/kafka" --strip-components=1
+  kafka-exporter:
+    plugin: nil
+    override-build: |
+      archive="kafka-exporter.tar.gz"
+      curl -o "${archive}" "https://github.com/danielqsj/kafka_exporter/releases/download/v1.6.0/kafka_exporter-1.6.0.linux-amd64.tar.gz"
       tar -xzvf "${archive}" -C "${CRAFT_PART_INSTALL}/opt/kafka" --strip-components=1
   prometheus-exporter:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,105 +24,148 @@ apps:
     command: start-zookeeper-wrapper.bash
     daemon: simple
     install-mode: disable
-    plugs: [network, network-bind, removable-media]
+    plugs:
+      - network
+      - network-bind
+      - removable-media
   configs:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-configs.sh
   topics:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-topics.sh
   console-consumer:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-console-consumer.sh
   console-producer:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-console-producer.sh
   consumer-groups:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-consumer-groups.sh
   get-offsets:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-get-offsets.sh
   reassign-partitions:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-reassign-partitions.sh
   replica-verification:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-replica-verification.sh
   zookeeper-shell:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: zookeeper-shell.sh
   run-class:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-run-class.sh
   kafka-streams-application-reset:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-streams-application-reset.sh
   transactions:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-transactions.sh
   leader-election:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-leader-election.sh
   dump-log:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-dump-log.sh
   acls:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-acls.sh
   cluster:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-cluster.sh
   verifiable-consumer:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-verifiable-consumer.sh
   verifiable-producer:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: kafka-verifiable-producer.sh
   trogdor:
     command: script-wrapper.bash
-    plugs: [network, network-bind]
+    plugs:
+      - network
+      - network-bind
     environment:
       _wrapper_script: trogdor.sh
   exporter:
     command: opt/kafka/kafka_exporter
-    plugs: [network, network-bind, removable-media]
+    plugs:
+      - network
+      - network-bind
 
 parts:
   dependencies:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -165,7 +165,7 @@ apps:
     environment:
       _wrapper_script: trogdor.sh
   exporter:
-    command: kafka_exporter
+    command: exporter-wrapper.bash
     daemon: simple
     install-mode: disable
     plugs:
@@ -191,10 +191,11 @@ parts:
       tar -xzvf "${archive}" -C "${CRAFT_PART_INSTALL}/opt/kafka" --strip-components=1
   kafka-exporter:
     plugin: nil
+    after: [kafka]
     override-build: |
       exporter="kafka_exporter-1.6.0.linux-amd64.tar.gz"
       curl -sLo "${exporter}" "https://github.com/danielqsj/kafka_exporter/releases/download/v1.6.0/${exporter}"
-      tar -xvf "${exporter}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1
+      tar -xvf "${exporter}" -C "${CRAFT_PART_INSTALL}/opt/kafka" --strip-components=1
   prometheus-exporter:
     plugin: nil
     after: [kafka]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -195,7 +195,10 @@ parts:
     override-build: |
       exporter="kafka_exporter-1.6.0.linux-amd64.tar.gz"
       curl -sLo "${exporter}" "https://github.com/danielqsj/kafka_exporter/releases/download/v1.6.0/${exporter}"
-      tar -xvf "${exporter}" -C "${CRAFT_PART_INSTALL}/opt/kafka" --strip-components=1
+      tar -xvf "${exporter}" --strip-components=1
+      cp kafka_exporter $CRAFT_PART_INSTALL/
+    organize:
+      kafka_exporter: opt/kafka/kafka_exporter
   prometheus-exporter:
     plugin: nil
     after: [kafka]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -166,6 +166,8 @@ apps:
       _wrapper_script: trogdor.sh
   exporter:
     command: kafka_exporter
+    daemon: simple
+    install-mode: disable
     plugs:
       - network
       - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,10 @@ apps:
     command: start-kafka-wrapper.bash
     daemon: simple
     install-mode: disable
-    plugs: [network, network-bind, removable-media]
+    plugs:
+      - network
+      - network-bind
+      - removable-media
   zookeeper:
     command: start-zookeeper-wrapper.bash
     daemon: simple
@@ -162,7 +165,7 @@ apps:
     environment:
       _wrapper_script: trogdor.sh
   exporter:
-    command: opt/kafka/kafka_exporter
+    command: kafka_exporter
     plugs:
       - network
       - network-bind
@@ -187,9 +190,9 @@ parts:
   kafka-exporter:
     plugin: nil
     override-build: |
-      archive="kafka-exporter.tar.gz"
-      curl -o "${archive}" "https://github.com/danielqsj/kafka_exporter/releases/download/v1.6.0/kafka_exporter-1.6.0.linux-amd64.tar.gz"
-      tar -xzvf "${archive}" -C "${CRAFT_PART_INSTALL}/opt/kafka" --strip-components=1
+      exporter="kafka_exporter-1.6.0.linux-amd64.tar.gz"
+      curl -sLo "${exporter}" "https://github.com/danielqsj/kafka_exporter/releases/download/v1.6.0/${exporter}"
+      tar -xvf "${exporter}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1
   prometheus-exporter:
     plugin: nil
     after: [kafka]


### PR DESCRIPTION
## Changes Made
##### `feat: make available pre-built kafka-exporter binaries pulled from GitHub`
##### `feat: expose kafka_exporter via snap app`
- This was to avoid potentially weird (and not possible?) behavior when running a persistent subprocess from within the charm
##### `chore: add exporter-wrapper for building necessary exporter command-line args`
- The exporter expects command-line args when ran
- It is not easy to pass arguments into a `snap start X.Y` command
- The wrapper Bash script grabs an `exporter.properties` file (to be) created by the charm, and parses out the necessary args
    - `--tls.enabled` only applies when `SSL` is found in `security.protocol`
    - Other `--tls.X` can safely be passed without needing to be used, using expected paths set by the charm