### PR TITLE
fix: don't use jmx opts for bin commands

### DIFF
--- a/snap/local/opt/kafka/bin-wrapper.bash
+++ b/snap/local/opt/kafka/bin-wrapper.bash
@@ -2,4 +2,6 @@
 
 set -eu
 
+unset KAFKA_JMX_OPTS
+
 ${SNAP}/bin/${bin_script} "${@}"


### PR DESCRIPTION
## Changes Made
##### `fix: unset KAFKA_JMX_OPTS`
- Breaks if ran alongside the main service as the port is in use