### PR TITLE
[DPE-2403] Update Kafka version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: charmed-kafka_snap_amd64
-          path: charmed-kafka_${{ steps.get-version.output.version }}_amd64.snap
+          path: charmed-kafka_${{ steps.get-version.outputs.version }}_amd64.snap
     outputs:
       snap-file: ${{ steps.snapcraft.outputs.snap }}
       version: ${{ steps.get-version.outputs.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: Build and Test
 
 env:
-  VERSION: 3.3.2
+  VERSION: 3.4.1
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,5 @@
 name: Build and Test
 
-env:
-  VERSION: 3.4.1
-
 on:
   workflow_dispatch:
   pull_request:
@@ -11,8 +8,6 @@ jobs:
   build:
     name: Build Snap
     runs-on: ubuntu-latest
-    outputs:
-      snap-file: ${{ steps.snapcraft.outputs.snap }}
     steps:
       - id: checkout
         name: Checkout repository
@@ -26,6 +21,12 @@ jobs:
           sudo apt-mark hold grub-efi-amd64-signed grub-efi-amd64-bin
           sudo DEBIAN_FRONTEND=noninteractive apt upgrade --yes
 
+      - id: get-version
+        name: Retrieve workload version
+        run: |
+          VERSION=$(yq '(.version|split("-"))[0]' snap/snapcraft.yaml)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
       - id: snapcraft
         name: Build snap
         uses: snapcore/action-build@v1
@@ -35,7 +36,10 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: charmed-kafka_snap_amd64
-          path: charmed-kafka_${{env.VERSION}}_amd64.snap
+          path: charmed-kafka_${{ steps.get-version.output.version }}_amd64.snap
+    outputs:
+      snap-file: ${{ steps.snapcraft.outputs.snap }}
+      version: ${{ steps.get-version.outputs.version }}
 
   test:
     name: Test Snap
@@ -51,7 +55,7 @@ jobs:
 
       - name: Install snap file
         run: |
-          sudo snap install charmed-kafka_${{env.VERSION}}_amd64.snap --dangerous
+          sudo snap install charmed-kafka_${{ needs.build.outputs.version }}_amd64.snap --dangerous
           sudo snap install charmed-zookeeper --channel=3/edge
 
       - name: Set default config

--- a/.github/workflows/on_kafka_update_available.yaml
+++ b/.github/workflows/on_kafka_update_available.yaml
@@ -26,11 +26,16 @@ jobs:
         run: |
           VERSION=$(yq '(.version|split("-"))[0]' snap/snapcraft.yaml)
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          
+          BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+          echo "risk=${BRANCH##*\/}" >> $GITHUB_OUTPUT
+          echo "track=${BRANCH%*\/*}" >> $GITHUB_OUTPUT    
 
       - id: check-latest-version
         name: Check latest stable Kafka version available for download
         run: |
-          LATEST_STABLE_SPARK_VERSION=$(curl --silent https://downloads.apache.org/kafka/ | grep  "\[DIR\]" | cut -d'>' -f3 | cut -d'/' -f1  | sort | tail -n 1)
+          LATEST_STABLE_SPARK_VERSION=$(curl --silent https://downloads.apache.org/kafka/ | grep  "\[DIR\]" | cut -d'>' -f3 | cut -d'/' -f1  | grep "^${{ steps.get-current-version.outputs.track }}" | sort | tail -n 1)
           CURRENT_PUBLISHED_VERSION=${{ steps.get-current-version.outputs.version }}
           STATUSCODE=$(curl --silent --head https://downloads.apache.org/kafka/${LATEST_STABLE_SPARK_VERSION}/kafka_2.13-${LATEST_STABLE_SPARK_VERSION}.tgz | head -n 1 | cut -d' ' -f2)
           if  [[ ${LATEST_STABLE_SPARK_VERSION} != ${CURRENT_PUBLISHED_VERSION} ]] && [[ ${STATUSCODE} -eq 200 ]]

--- a/.github/workflows/on_kafka_update_available.yaml
+++ b/.github/workflows/on_kafka_update_available.yaml
@@ -1,0 +1,104 @@
+name: Detect upstream Kafka updates
+
+env:
+  BASE_BRANCH: 3/edge
+  UPDATE_BRANCH: bot/update-kafka-version
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 16 * * *'
+
+jobs:
+  check:
+    name: Check if Kafka update is available
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - id: checkout
+        name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.BASE_BRANCH }}
+
+      - id: get-current-version
+        name: Retrieve workload version
+        run: |
+          VERSION=$(yq '(.version|split("-"))[0]' snap/snapcraft.yaml)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - id: check-latest-version
+        name: Check latest stable Kafka version available for download
+        run: |
+          LATEST_STABLE_SPARK_VERSION=$(curl --silent https://downloads.apache.org/kafka/ | grep  "\[DIR\]" | cut -d'>' -f3 | cut -d'/' -f1  | sort | tail -n 1)
+          CURRENT_PUBLISHED_VERSION=${{ steps.get-current-version.outputs.version }}
+          STATUSCODE=$(curl --silent --head https://downloads.apache.org/kafka/${LATEST_STABLE_SPARK_VERSION}/kafka_2.13-${LATEST_STABLE_SPARK_VERSION}.tgz | head -n 1 | cut -d' ' -f2)
+          if  [[ ${LATEST_STABLE_SPARK_VERSION} != ${CURRENT_PUBLISHED_VERSION} ]] && [[ ${STATUSCODE} -eq 200 ]]
+            then 
+              echo "decision=1" >> $GITHUB_OUTPUT
+              echo "New Kafka version available....."
+            else
+              echo "decision=0" >> $GITHUB_OUTPUT
+              echo "No updates to Kafka detected!"
+          fi
+          echo "version=${LATEST_STABLE_SPARK_VERSION}" >> $GITHUB_OUTPUT
+    outputs:
+      decision: ${{ steps.check-latest-version.outputs.decision }}
+      latest: ${{ steps.check-latest-version.outputs.version }}
+      current: ${{ steps.get-current-version.outputs.version }}
+
+  create-or-update-pull-request:
+    name: Create or update pull request
+    if: needs.check.outputs.decision  ==  '1'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - check
+    steps:
+      - id: checkout
+        name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.BASE_BRANCH }}
+      - id: record_latest_version
+        name: Record updated Kafka version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b ${{ env.UPDATE_BRANCH}}
+          
+          # Update snapcraft file
+          
+          sed -i "/^version:/s/${{ needs.check.outputs.current }}/${{ needs.check.outputs.latest }}/" snap/snapcraft.yaml
+          git add ./snap/snapcraft.yaml
+          
+          git commit -m "Update Kafka Snap"
+          git push --set-upstream -f origin ${{ env.UPDATE_BRANCH}}
+      - id: check
+        name: Check if a PR already exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prs=$(gh pr list \
+           --json baseRefName,headRefName \
+           --jq '
+               map(select(.baseRefName == "${{ env.BASE_BRANCH }}" and .headRefName == "${{ env.UPDATE_BRANCH}}" ))
+               | length
+           ')
+          if ((prs > 0)); then
+           echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: create pull request
+        if: '!steps.check.outputs.skip'
+        id: cpr
+        run: gh pr create
+          --title "Update snap for new Kafka version"
+          --body "Update client snap with new version of Apache Kafka."
+          --base "${{ env.BASE_BRANCH }}"
+          --assignee deusebio
+          --reviewer deusebio
+          --label "automated pr"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on_kafka_update_available.yaml
+++ b/.github/workflows/on_kafka_update_available.yaml
@@ -35,10 +35,10 @@ jobs:
       - id: check-latest-version
         name: Check latest stable Kafka version available for download
         run: |
-          LATEST_STABLE_SPARK_VERSION=$(curl --silent https://downloads.apache.org/kafka/ | grep  "\[DIR\]" | cut -d'>' -f3 | cut -d'/' -f1  | grep "^${{ steps.get-current-version.outputs.track }}" | sort | tail -n 1)
+          LATEST_STABLE_VERSION=$(curl --silent https://downloads.apache.org/kafka/ | grep  "\[DIR\]" | cut -d'>' -f3 | cut -d'/' -f1  | grep "^${{ steps.get-current-version.outputs.track }}" | sort | tail -n 1)
           CURRENT_PUBLISHED_VERSION=${{ steps.get-current-version.outputs.version }}
-          STATUSCODE=$(curl --silent --head https://downloads.apache.org/kafka/${LATEST_STABLE_SPARK_VERSION}/kafka_2.13-${LATEST_STABLE_SPARK_VERSION}.tgz | head -n 1 | cut -d' ' -f2)
-          if  [[ ${LATEST_STABLE_SPARK_VERSION} != ${CURRENT_PUBLISHED_VERSION} ]] && [[ ${STATUSCODE} -eq 200 ]]
+          STATUSCODE=$(curl --silent --head https://downloads.apache.org/kafka/${LATEST_STABLE_VERSION}/kafka_2.13-${LATEST_STABLE_VERSION}.tgz | head -n 1 | cut -d' ' -f2)
+          if  [[ ${LATEST_STABLE_VERSION} != ${CURRENT_PUBLISHED_VERSION} ]] && [[ ${STATUSCODE} -eq 200 ]]
             then 
               echo "decision=1" >> $GITHUB_OUTPUT
               echo "New Kafka version available....."
@@ -46,7 +46,7 @@ jobs:
               echo "decision=0" >> $GITHUB_OUTPUT
               echo "No updates to Kafka detected!"
           fi
-          echo "version=${LATEST_STABLE_SPARK_VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${LATEST_STABLE_VERSION}" >> $GITHUB_OUTPUT
     outputs:
       decision: ${{ steps.check-latest-version.outputs.decision }}
       latest: ${{ steps.check-latest-version.outputs.version }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,9 +7,8 @@ on:
 
 jobs:
   checks:
-    name: Publish Snap
+    name: Check Metadata and branch consistency
     runs-on: ubuntu-latest
-    needs: build
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
@@ -33,6 +32,7 @@ jobs:
 
   build:
     name: Build snap
+    needs: checks
     uses: canonical/data-platform-workflows/.github/workflows/build_snap_without_cache.yaml@v2
 
   publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  checks:
+    name: Publish Snap
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: get-current-version
+        name: Retrieve Metadata
+        run: |
+          VERSION=$(yq '(.version|split("-"))[0]' snap/snapcraft.yaml)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          
+          BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+          echo "risk=${BRANCH##*\/}" >> $GITHUB_OUTPUT
+          echo "track=${BRANCH%*\/*}" >> $GITHUB_OUTPUT    
+
+      - name: Check consistency between metadata and release branch
+        run: |
+          MAJOR_VERSION=$(echo ${{ steps.get-current-version.outputs.version }} | sed -n "s/\(^[0-9]*\).*/\1/p")
+          if [ "${MAJOR_VERSION}" != "${{ steps.get-current-version.outputs.track }}" ]; then exit 1; fi
+        continue-on-error: false
+
   build:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap_without_cache.yaml@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - '[0-9]/[a-z]+'
+      - '3/[a-z]+'
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,17 +1,39 @@
 on:
+  push:
+    branches:
+      - '[0-9]/[a-z]+'
   workflow_call:
   workflow_dispatch:
 
 jobs:
+  build:
+    name: Build snap
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap_without_cache.yaml@v2
+
   publish:
+    name: Publish Snap
     runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
-      - uses: snapcore/action-build@v1
-        id: build
-      - uses: snapcore/action-publish@v1
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.artifact-name }}
+      - id: get-snap-name
+        run: echo "SNAP_FILE=$(ls *.snap)" >> $GITHUB_OUTPUT
+      - name: Publish snap
+        id: publish
+        uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
-          snap: ${{ steps.build.outputs.snap }}
+          snap: ${{ steps.get-snap-name.outputs.SNAP_FILE }}
           release: ${{ github.ref_name }}
+      - name: Upload snapcraft logs
+        if: ${{ failure() && steps.publish.outcome == 'failure' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: snapcraft-release-logs
+          path: ~/.local/state/snapcraft/log/
+          if-no-files-found: error

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,3 +1,5 @@
+name: Publish new Kafka SNAP revision
+
 on:
   push:
     branches:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-kafka
 base: core22
-version: '3.4.0'
+version: '3.4.1'
 summary: Apache Kafka in a snap.
 description: |
   This is a snap that bundles Apache Kafka together with other tools of its ecosystem in order to be used in Charmed Operators, providing automated operations management from day 0 to day 2 on the Apache Kafka real-time stream processing, on top of a Virtual Machine cluster and K8s cluster. It is an open source, end-to-end, production ready data platform on top of cloud native technologies.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-kafka
 base: core22
-version: '3.3.2'
+version: '3.4.0'
 summary: Apache Kafka in a snap.
 description: |
   This is a snap that bundles Apache Kafka together with other tools of its ecosystem in order to be used in Charmed Operators, providing automated operations management from day 0 to day 2 on the Apache Kafka real-time stream processing, on top of a Virtual Machine cluster and K8s cluster. It is an open source, end-to-end, production ready data platform on top of cloud native technologies.


### PR DESCRIPTION
This PR aims at enabling aumatic upgrade of Kafka versions for SNAPs on the 3/ track. 

To do so, it includes these points:
* Increase the version of Kafka to 3.4.1
* Enabled schedule workflows for checking if a new Kafka version was released, and in this case it automatically raise a PR (an example of this can be seen [here](https://github.com/deusebio/charmed-kafka-snap/actions/runs/5900741631))
* Enable continuous delivery of SNAPs, as these are release to 3/* branches