### PR TITLE
DPE-1965 - feat: expose keytool app

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -197,6 +197,8 @@ apps:
       - network-bind
     environment:
       bin_script: trogdor.sh
+  keytool:
+    command: usr/lib/jvm/java-17-openjdk-amd64/bin/keytool
 
 parts:
   kafka:


### PR DESCRIPTION
## Changes Made
#### `feat: expose keytool app`
- Avoids having to pull `openjdk-17-jre-headless` from `apt` as it comes with the snap