### PR TITLE
[DPE-4297] Introduce retention

### DIFF
--- a/snap/local/etc/kafka/log4j.properties
+++ b/snap/local/etc/kafka/log4j.properties
@@ -1,4 +1,5 @@
 charmed.kafka.log.level=INFO
+charmed.kafka.log.retention=7
 
 log4j.rootLogger=${charmed.kafka.log.level}, kafkaAppender
 
@@ -11,36 +12,42 @@ log4j.appender.kafkaAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log
 log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.kafkaAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
 log4j.appender.stateChangeAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.stateChangeAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.stateChangeAppender.File=${kafka.logs.dir}/state-change.log
 log4j.appender.stateChangeAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.stateChangeAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.stateChangeAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
 log4j.appender.requestAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.requestAppender.File=${kafka.logs.dir}/kafka-request.log
 log4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.requestAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
 log4j.appender.cleanerAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.cleanerAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.cleanerAppender.File=${kafka.logs.dir}/log-cleaner.log
 log4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.cleanerAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
 log4j.appender.controllerAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.controllerAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.controllerAppender.File=${kafka.logs.dir}/controller.log
 log4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.controllerAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
 log4j.appender.authorizerAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.authorizerAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.authorizerAppender.File=${kafka.logs.dir}/kafka-authorizer.log
 log4j.appender.authorizerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.authorizerAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
 # Change the line below to adjust ZK client logging
 log4j.logger.org.apache.zookeeper=${charmed.kafka.log.level}

--- a/snap/local/etc/kafka/log4j.properties
+++ b/snap/local/etc/kafka/log4j.properties
@@ -21,40 +21,40 @@ log4j.appender.stateChangeAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.stateChangeAppender.File=${kafka.logs.dir}/state-change.log
 log4j.appender.stateChangeAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.stateChangeAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
-log4j.appender.kafkaAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
-log4j.appender.kafkaAppender.MaxBackupIndex=${charmed.kafka.log.retention}
+log4j.appender.stateChangeAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
+log4j.appender.stateChangeAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
 log4j.appender.requestAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.requestAppender.File=${kafka.logs.dir}/kafka-request.log
 log4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
-log4j.appender.kafkaAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
-log4j.appender.kafkaAppender.MaxBackupIndex=${charmed.kafka.log.retention}
+log4j.appender.requestAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
+log4j.appender.requestAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
 log4j.appender.cleanerAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.cleanerAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.cleanerAppender.File=${kafka.logs.dir}/log-cleaner.log
 log4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
-log4j.appender.kafkaAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
-log4j.appender.kafkaAppender.MaxBackupIndex=${charmed.kafka.log.retention}
+log4j.appender.cleanerAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
+log4j.appender.cleanerAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
 log4j.appender.controllerAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.controllerAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.controllerAppender.File=${kafka.logs.dir}/controller.log
 log4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
-log4j.appender.kafkaAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
-log4j.appender.kafkaAppender.MaxBackupIndex=${charmed.kafka.log.retention}
+log4j.appender.controllerAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
+log4j.appender.controllerAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
 log4j.appender.authorizerAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.authorizerAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.authorizerAppender.File=${kafka.logs.dir}/kafka-authorizer.log
 log4j.appender.authorizerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
-log4j.appender.kafkaAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
-log4j.appender.kafkaAppender.MaxBackupIndex=${charmed.kafka.log.retention}
+log4j.appender.authorizerAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
+log4j.appender.authorizerAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
 # Change the line below to adjust ZK client logging
 log4j.logger.org.apache.zookeeper=${charmed.kafka.log.level}

--- a/snap/local/etc/kafka/log4j.properties
+++ b/snap/local/etc/kafka/log4j.properties
@@ -1,5 +1,6 @@
 charmed.kafka.log.level=INFO
-charmed.kafka.log.retention=7
+charmed.kafka.log.maxfilesize=100MB
+charmed.kafka.log.retention=10
 
 log4j.rootLogger=${charmed.kafka.log.level}, kafkaAppender
 
@@ -7,47 +8,53 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.kafkaAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.kafkaAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.kafkaAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log
 log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.kafkaAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
 log4j.appender.kafkaAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
-log4j.appender.stateChangeAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.stateChangeAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.stateChangeAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.stateChangeAppender.File=${kafka.logs.dir}/state-change.log
 log4j.appender.stateChangeAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.stateChangeAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
-log4j.appender.stateChangeAppender.MaxBackupIndex=${charmed.kafka.log.retention}
+log4j.appender.kafkaAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
+log4j.appender.kafkaAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
-log4j.appender.requestAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.requestAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.requestAppender.File=${kafka.logs.dir}/kafka-request.log
 log4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
-log4j.appender.requestAppender.MaxBackupIndex=${charmed.kafka.log.retention}
+log4j.appender.kafkaAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
+log4j.appender.kafkaAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
-log4j.appender.cleanerAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.cleanerAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.cleanerAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.cleanerAppender.File=${kafka.logs.dir}/log-cleaner.log
 log4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
-log4j.appender.cleanerAppender.MaxBackupIndex=${charmed.kafka.log.retention}
+log4j.appender.kafkaAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
+log4j.appender.kafkaAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
-log4j.appender.controllerAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.controllerAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.controllerAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.controllerAppender.File=${kafka.logs.dir}/controller.log
 log4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
-log4j.appender.controllerAppender.MaxBackupIndex=${charmed.kafka.log.retention}
+log4j.appender.kafkaAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
+log4j.appender.kafkaAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
-log4j.appender.authorizerAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.authorizerAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.authorizerAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.authorizerAppender.File=${kafka.logs.dir}/kafka-authorizer.log
 log4j.appender.authorizerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
-log4j.appender.authorizerAppender.MaxBackupIndex=${charmed.kafka.log.retention}
+log4j.appender.kafkaAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
+log4j.appender.kafkaAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
 # Change the line below to adjust ZK client logging
 log4j.logger.org.apache.zookeeper=${charmed.kafka.log.level}


### PR DESCRIPTION
Docs for [`DailyRollingFileAppender`](https://logging.apache.org/log4j/1.x/apidocs/org/apache/log4j/DailyRollingFileAppender.html) mention that alternatives should be used. I think the alternative is to use [rolling.RollingFileAppender](https://logging.apache.org/log4j/extras/apidocs/org/apache/log4j/rolling/RollingFileAppender.html), but I didn't find a clear example of an in place replacement for the old class. I'm using the `RollingFileAppender` class instead.