### PR TITLE
[DPE-4779] Add Kraft test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,8 @@ jobs:
       snap-file: ${{ steps.snapcraft.outputs.snap }}
       version: ${{ steps.get-version.outputs.version }}
 
-  test:
-    name: Test Snap
+  test-with-zk:
+    name: Test Snap with ZooKeeper
     runs-on: ubuntu-latest
     needs:
       - build
@@ -87,3 +87,39 @@ jobs:
           sudo snap start charmed-kafka.cruise-control
           sleep 20
           curl -s http://localhost:9090/kafkacruisecontrol/state | grep "state: RUNNING"
+
+  test-with-kraft:
+    name: Test Snap with Kraft
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download snap file
+        uses: actions/download-artifact@v3
+        with:
+          name: charmed-kafka_snap_amd64
+          path: .
+
+      - name: Install snap file
+        run: |
+          sudo snap install charmed-kafka_${{ needs.build.outputs.version }}_amd64.snap --dangerous
+
+      - name: Set default kraft config
+        run: |
+          sudo cp /snap/charmed-kafka/current/opt/kafka/config/kraft/server.properties /var/snap/charmed-kafka/current/etc/kafka
+
+          sed -i '/log.dirs=/c\log.dirs=/var/snap/charmed-kafka/common/var/log/kafka' /var/snap/charmed-kafka/current/etc/kafka/server.properties
+          uuid=$(charmed-kafka.storage random-uuid)
+          charmed-kafka.storage format --cluster-id $uuid -c /var/snap/charmed-kafka/current/etc/kafka/server.properties
+
+      - name: Start snap services
+        run: |
+          sudo snap start charmed-kafka.daemon
+          sleep 5
+
+      - name: Check topic creation
+        run: |
+          topic_creation=$(charmed-kafka.topics --create --topic test --bootstrap-server localhost:9092)
+          if [ "$topic_creation" != "Created topic test." ]; then
+              exit 1
+          fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
         run: |
           sudo cp /snap/charmed-kafka/current/opt/kafka/config/kraft/server.properties /var/snap/charmed-kafka/current/etc/kafka
 
-          sed -i '/log.dirs=/c\log.dirs=/var/snap/charmed-kafka/common/var/log/kafka' /var/snap/charmed-kafka/current/etc/kafka/server.properties
+          sudo sed -i '/log.dirs=/c\log.dirs=/var/snap/charmed-kafka/common/var/log/kafka' /var/snap/charmed-kafka/current/etc/kafka/server.properties
           uuid=$(charmed-kafka.storage random-uuid)
           charmed-kafka.storage format --cluster-id $uuid -c /var/snap/charmed-kafka/current/etc/kafka/server.properties
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,8 +109,8 @@ jobs:
           sudo cp /snap/charmed-kafka/current/opt/kafka/config/kraft/server.properties /var/snap/charmed-kafka/current/etc/kafka
 
           sudo sed -i '/log.dirs=/c\log.dirs=/var/snap/charmed-kafka/common/var/log/kafka' /var/snap/charmed-kafka/current/etc/kafka/server.properties
-          uuid=$(charmed-kafka.storage random-uuid)
-          charmed-kafka.storage format --cluster-id $uuid -c /var/snap/charmed-kafka/current/etc/kafka/server.properties
+          uuid=$(sudo charmed-kafka.storage random-uuid)
+          sudo charmed-kafka.storage format --cluster-id $uuid -c /var/snap/charmed-kafka/current/etc/kafka/server.properties
 
       - name: Start snap services
         run: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,7 +69,7 @@ apps:
       - network-bind
       - mount-observe
     environment:
-      bin_script: storage.sh
+      bin_script: kafka-storage.sh
   consumer-perf-test:
     command: opt/kafka/bin/bin-wrapper.bash
     plugs:


### PR DESCRIPTION
Adds Kraft test to the snap.

- `storage` binary entrypoint fixed
- Kraft deployment requires a manual format of the log directories. This has been added to the test