### PR TITLE
[DPE-4502] Add jmx for cruise control

### DIFF
--- a/snap/local/etc/cruise-control/jmx_cruise_control.yaml
+++ b/snap/local/etc/cruise-control/jmx_cruise_control.yaml
@@ -1,0 +1,5 @@
+  lowercaseOutputName: true
+  rules:
+  - pattern: kafka.cruisecontrol<name=(.+)><>(\w+)
+    name: kafka_cruisecontrol_$1_$2
+    type: GAUGE

--- a/snap/local/opt/cruise-control/bin/start-wrapper.bash
+++ b/snap/local/opt/cruise-control/bin/start-wrapper.bash
@@ -2,7 +2,13 @@
 
 set -e
 
-unset KAFKA_JMX_OPTS
+# Cruise control uses the same var for JMX metrics. To allow both to be used on the same machine, 
+# use a specific var for CC and override during startup.
+if [ "x$CC_JMX_OPTS" != "x" ]; then
+    export KAFKA_JMX_OPTS=${CC_JMX_OPTS}
+else
+    unset KAFKA_JMX_OPTS
+fi
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dcruisecontrol.logs.dir=${LOG_DIR} -Dlog4j.configurationFile=${SNAP_DATA}/etc/cruise-control/log4j.properties -Dcruisecontrol.log.level=${KAFKA_CFG_LOGLEVEL:-INFO}"


### PR DESCRIPTION
Adds the basic config file for the exporter. 

A new env var is expected to be set by the charm/user to enable JMX exporter on CC. Both Kafka and CC daemons use the env `KAFKA_JMX_OPTS` to enable the exporter, now the CC daemon will look if an env called `CC_JMX_OPTS` exists and override the main one.