### PR TITLE
fix: remove errors from bin commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Check topic creation
         run: |
           topic_creation=$(charmed-kafka.topics --create --topic __CruiseControlMetrics --bootstrap-server localhost:9092)
-          if [ "$topic_creation" != "Created topic __CruiseControlMetrics." ]; then
+          if [ "$topic_creation" != *"Created topic __CruiseControlMetrics."* ]; then
               echo $topic_creation
               exit 1
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,10 +79,11 @@ jobs:
       - name: Check topic creation
         run: |
           topic_creation=$(charmed-kafka.topics --create --topic __CruiseControlMetrics --bootstrap-server localhost:9092)
-          if [ "$topic_creation" != *"Created topic __CruiseControlMetrics." ]; then
-              echo $topic_creation
-              exit 1
+          if [[ "$topic_creation" == *"Created topic __CruiseControlMetrics."* ]]; then
+              exit 0
           fi
+          echo $topic_creation
+          exit 1
 
       - name: Check CruiseControl state
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Check topic creation
         run: |
-          topic_creation=$(charmed-kafka.topics --create --topic "__CruiseControlMetrics" --bootstrap-server localhost:9092)
+          topic_creation=$(charmed-kafka.topics --create --topic __CruiseControlMetrics --bootstrap-server localhost:9092)
           if [ "$topic_creation" != "Created topic __CruiseControlMetrics. ]; then
               echo $topic_creation
               exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,8 +78,9 @@ jobs:
 
       - name: Check topic creation
         run: |
-          topic_creation=$(charmed-kafka.topics --create --topic test --bootstrap-server localhost:9092)
-          if [ "$topic_creation" != "Created topic test." ]; then
+          topic_creation=$(charmed-kafka.topics --create --topic "__CruiseControlMetrics" --bootstrap-server localhost:9092)
+          if [ "$topic_creation" != "Created topic __CruiseControlMetrics. ]; then
+              echo $topic_creation
               exit 1
           fi
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Check topic creation
         run: |
           topic_creation=$(charmed-kafka.topics --create --topic __CruiseControlMetrics --bootstrap-server localhost:9092)
-          if [ "$topic_creation" != "Created topic __CruiseControlMetrics. ]; then
+          if [ "$topic_creation" != "Created topic __CruiseControlMetrics." ]; then
               echo $topic_creation
               exit 1
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Check topic creation
         run: |
           topic_creation=$(charmed-kafka.topics --create --topic __CruiseControlMetrics --bootstrap-server localhost:9092)
-          if [ "$topic_creation" != *"Created topic __CruiseControlMetrics."* ]; then
+          if [ "$topic_creation" != *"Created topic __CruiseControlMetrics." ]; then
               echo $topic_creation
               exit 1
           fi

--- a/snap/local/opt/kafka/bin/bin-wrapper.bash
+++ b/snap/local/opt/kafka/bin/bin-wrapper.bash
@@ -3,6 +3,7 @@
 set -e
 
 unset KAFKA_JMX_OPTS
+export LOG_DIR="${SNAP_DATA}/var/log/kafka"
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:${SNAP_DATA}/etc/kafka/tools-log4j.properties -Dcharmed.kafka.log.level=WARN",

--- a/snap/local/opt/kafka/bin/bin-wrapper.bash
+++ b/snap/local/opt/kafka/bin/bin-wrapper.bash
@@ -3,7 +3,7 @@
 set -e
 
 unset KAFKA_JMX_OPTS
-export LOG_DIR="${SNAP_DATA}/var/log/kafka"
+export LOG_DIR="${SNAP_COMMON}/var/log/kafka"
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:${SNAP_DATA}/etc/kafka/tools-log4j.properties -Dcharmed.kafka.log.level=WARN",


### PR DESCRIPTION
## Changes Made
#### `fix: remove log errors from bin commands`
- Before:
    ```
    root@juju-4ada6d-0:~# charmed-kafka.topics --version
	mkdir: cannot create directory ‘/snap/charmed-kafka/54/opt/kafka/bin/../logs’: Read-only file system
	3.9.0-ubuntu0
	```
- After:
    ```
    root@juju-4ada6d-0:~# charmed-kafka.topics --version
	3.9.0-ubuntu0
	```