### PR TITLE
fix: set content source attribute to be the same as grafana-agent

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,21 +23,25 @@ environment:
 slots:
   kafka-logs:
     interface: content
+    content: logs
     source:
       read:
         - $SNAP_COMMON/var/log/kafka
   kraft-logs:
     interface: content
+    content: logs
     source:
       read:
         - $SNAP_COMMON/var/log/kraft
   cc-logs:
     interface: content
+    content: logs
     source:
       read:
         - $SNAP_COMMON/var/log/cruise-control
   connect-logs:
     interface: content
+    content: logs
     source:
       read:
         - $SNAP_COMMON/var/log/connect


### PR DESCRIPTION
## Changes Made
#### `fix: set content source attribute to be the same as grafana-agent`
- Logs weren't being picked up by the `grafana-agent` Snap. Bug introduced when the slot name changed from `logs` -> `kafka-logs`
- MM thread can be found - https://chat.canonical.com/canonical/pl/dngaw7d5jirp9x5551yqzkgimh
- Snapd bug report - https://bugs.launchpad.net/snapd/+bug/2106478