### PR TITLE
[DPE-7152] Update to core24 and Kafka 4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,7 @@ jobs:
       - name: Check topic creation
         run: |
           topic_creation=$(charmed-kafka.topics --create --topic test --bootstrap-server localhost:9092)
+          echo $topic_creation
           if [ "$topic_creation" != "Created topic test." ]; then
               exit 1
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
         run: |
           topic_creation=$(charmed-kafka.topics --create --topic test --bootstrap-server localhost:9092)
           echo $topic_creation
-          if [ "$topic_creation" != "Created topic test." ]; then
+          if [ "$topic_creation" != *"Created topic test."* ]; then
               exit 1
           fi
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,9 +75,9 @@ jobs:
       - name: Start snap services
         run: |
           sudo snap start charmed-kafka.controller
-          sleep 5
+          sleep 10
           sudo snap start charmed-kafka.daemon
-          sleep 5
+          sleep 10
 
       - name: Check topic creation
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,7 +131,7 @@ jobs:
           sudo charmed-kafka.storage format --cluster-id $uuid -c /var/snap/charmed-kafka/current/etc/kafka/server.properties
           sudo charmed-kafka.storage format --standalone --cluster-id $uuid -c /var/snap/charmed-kafka/current/etc/kraft/controller.properties
 
-          sudo chown -R snap_daemon:snap_daemon /var/snap/charmed-kafka/common/var/log/kraft
+          sudo chown -R _daemon_:_daemon_ /var/snap/charmed-kafka/common/var/log/kraft
 
       - name: Start snap services
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,67 +41,6 @@ jobs:
       snap-file: ${{ steps.snapcraft.outputs.snap }}
       version: ${{ steps.get-version.outputs.version }}
 
-  test-with-zk:
-    name: Test Snap with ZooKeeper
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      - name: Download snap file
-        uses: actions/download-artifact@v4
-        with:
-          name: charmed-kafka_snap_amd64
-          path: .
-
-      - name: Install snap file
-        run: |
-          sudo snap install charmed-kafka_${{ needs.build.outputs.version }}_amd64.snap --dangerous
-          sudo snap install charmed-zookeeper --channel=3/edge
-
-      - name: Set default config
-        run: |
-          sudo cp /snap/charmed-kafka/current/opt/kafka/config/server.properties /var/snap/charmed-kafka/current/etc/kafka
-          sudo cp /snap/charmed-zookeeper/current/opt/zookeeper/conf/zoo_sample.cfg /var/snap/charmed-zookeeper/current/etc/zookeeper/zoo.cfg
-          sudo cp /snap/charmed-kafka/current/opt/kafka/config/connect-distributed.properties /var/snap/charmed-kafka/current/etc/connect
-
-          sudo cp /snap/charmed-kafka/current/opt/cruise-control/config/cruisecontrol.properties /var/snap/charmed-kafka/current/etc/cruise-control
-          sudo sed -i -e 's/sample.store.topic.replication.factor=2/sample.store.topic.replication.factor=1/g' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
-          sudo sed -i -e 's|capacity.config.file=config/capacityJBOD.json|capacity.config.file=/var/snap/charmed-kafka/current/etc/cruise-control/capacityJBOD.json|g' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
-          sudo cp /snap/charmed-kafka/current/opt/cruise-control/config/capacityJBOD.json /var/snap/charmed-kafka/current/etc/cruise-control
-
-      - name: Start snap services
-        run: |
-          sudo snap start charmed-zookeeper.daemon
-          sleep 5
-          sudo snap start charmed-kafka.daemon
-          sleep 5
-
-      - name: Check topic creation
-        run: |
-          topic_creation=$(charmed-kafka.topics --create --topic __CruiseControlMetrics --bootstrap-server localhost:9092)
-          if [[ "$topic_creation" == *"Created topic __CruiseControlMetrics."* ]]; then
-              exit 0
-          fi
-          echo $topic_creation
-          exit 1
-
-      - name: Check CruiseControl state
-        run: |
-          sudo snap start charmed-kafka.cruise-control
-          sleep 20
-          curl -s http://localhost:9090/kafkacruisecontrol/state | grep "state: RUNNING"
-
-      - name: Test connect service
-        run: |
-          sudo snap start charmed-kafka.connect-distributed
-          sleep 20
-          result=$(curl -s http://localhost:8083)
-          echo $result
-          if [[ "$result" == *"kafka_cluster_id"* ]]; then
-              exit 0
-          fi
-          exit 1
-
   test-with-kraft:
     name: Test Snap in Kraft mode
     runs-on: ubuntu-latest
@@ -120,8 +59,8 @@ jobs:
 
       - name: Set default kraft config
         run: |
-          sudo cp /snap/charmed-kafka/current/opt/kafka/config/kraft/broker.properties /var/snap/charmed-kafka/current/etc/kafka/server.properties
-          sudo cp /snap/charmed-kafka/current/opt/kafka/config/kraft/controller.properties /var/snap/charmed-kafka/current/etc/kraft/controller.properties
+          sudo cp /snap/charmed-kafka/current/opt/kafka/config/broker.properties /var/snap/charmed-kafka/current/etc/kafka/server.properties
+          sudo cp /snap/charmed-kafka/current/opt/kafka/config/controller.properties /var/snap/charmed-kafka/current/etc/kraft/controller.properties
           sudo cp /snap/charmed-kafka/current/opt/kafka/config/connect-distributed.properties /var/snap/charmed-kafka/current/etc/connect
 
           sudo sed -i '/log.dirs=/c\log.dirs=/var/snap/charmed-kafka/common/var/log/kafka' /var/snap/charmed-kafka/current/etc/kafka/server.properties

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,6 +68,9 @@ jobs:
           sudo sed -i '/log.dirs=/c\log.dirs=/var/snap/charmed-kafka/common/var/log/kraft' /var/snap/charmed-kafka/current/etc/kraft/controller.properties
           sudo sed -i -e 's/sample.store.topic.replication.factor=2/sample.store.topic.replication.factor=1/g' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
           sudo sed -i -e 's|capacity.config.file=config/capacityJBOD.json|capacity.config.file=/var/snap/charmed-kafka/current/etc/cruise-control/capacityJBOD.json|g' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
+          sudo sed -i -e '/zookeeper.connect=localhost:2181\//c\# zookeeper.connect=localhost:2181/' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
+          sudo sed -i -e '/zookeeper.security.enabled=false/c\# zookeeper.security.enabled=false' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
+          sudo sed -i -e '/# zookeeper.security.enabled=false/a\kafka.broker.failure.detection.enable=true\n' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
 
           sudo cp /snap/charmed-kafka/current/opt/cruise-control/config/capacityJBOD.json /var/snap/charmed-kafka/current/etc/cruise-control
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,8 @@ jobs:
       snap-file: ${{ steps.snapcraft.outputs.snap }}
       version: ${{ steps.get-version.outputs.version }}
 
-  test-with-kraft:
-    name: Test Snap in Kraft mode
+  test:
+    name: Test Snap
     runs-on: ubuntu-latest
     needs:
       - build
@@ -62,9 +62,14 @@ jobs:
           sudo cp /snap/charmed-kafka/current/opt/kafka/config/broker.properties /var/snap/charmed-kafka/current/etc/kafka/server.properties
           sudo cp /snap/charmed-kafka/current/opt/kafka/config/controller.properties /var/snap/charmed-kafka/current/etc/kraft/controller.properties
           sudo cp /snap/charmed-kafka/current/opt/kafka/config/connect-distributed.properties /var/snap/charmed-kafka/current/etc/connect
+          sudo cp /snap/charmed-kafka/current/opt/cruise-control/config/cruisecontrol.properties /var/snap/charmed-kafka/current/etc/cruise-control
 
           sudo sed -i '/log.dirs=/c\log.dirs=/var/snap/charmed-kafka/common/var/log/kafka' /var/snap/charmed-kafka/current/etc/kafka/server.properties
           sudo sed -i '/log.dirs=/c\log.dirs=/var/snap/charmed-kafka/common/var/log/kraft' /var/snap/charmed-kafka/current/etc/kraft/controller.properties
+          sudo sed -i -e 's/sample.store.topic.replication.factor=2/sample.store.topic.replication.factor=1/g' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
+          sudo sed -i -e 's|capacity.config.file=config/capacityJBOD.json|capacity.config.file=/var/snap/charmed-kafka/current/etc/cruise-control/capacityJBOD.json|g' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
+
+          sudo cp /snap/charmed-kafka/current/opt/cruise-control/config/capacityJBOD.json /var/snap/charmed-kafka/current/etc/cruise-control
 
           uuid=$(sudo charmed-kafka.storage random-uuid)
           sudo charmed-kafka.storage format --cluster-id $uuid -c /var/snap/charmed-kafka/current/etc/kafka/server.properties
@@ -81,13 +86,13 @@ jobs:
 
       - name: Check topic creation
         run: |
-          topic_creation=$(charmed-kafka.topics --create --topic test --bootstrap-server localhost:9092)
+          topic_creation=$(charmed-kafka.topics --create --topic __CruiseControlMetrics --bootstrap-server localhost:9092)
           echo $topic_creation
-          if [ "$topic_creation" != *"Created topic test."* ]; then
+          if [[ "$topic_creation" != *"Created topic __CruiseControlMetrics."* ]]; then
               exit 1
           fi
 
-      - name: Test connect service
+      - name: Test Connect service
         run: |
           sudo snap start charmed-kafka.connect-distributed
           sleep 20
@@ -97,3 +102,9 @@ jobs:
               exit 0
           fi
           exit 1
+
+      - name: Check CruiseControl state
+        run: |
+          sudo snap start charmed-kafka.cruise-control
+          sleep 20
+          curl -s http://localhost:9090/kafkacruisecontrol/state | grep "state: RUNNING"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To build locally, use `snapcraft --debug`
 Install the snap (e.g. `sudo snap install ./charmed-kafka_3.6.0_amd64.snap --dangerous --devmode`
 ).
 
-To run the snap, you will require to set up a controller service and the Kafka service. You can use the following:
+To run the snap, you will require to set up a KRaft controller service and the Kafka broker service. You can use the following:
 
 ```bash
 # copying default config

--- a/README.md
+++ b/README.md
@@ -70,9 +70,13 @@ To get started with Cruise Control, on a local system already running the Kafka 
 sudo cp /snap/charmed-kafka/current/opt/cruise-control/config/cruisecontrol.properties /var/snap/charmed-kafka/current/etc/cruise-control
 sudo cp /snap/charmed-kafka/current/opt/cruise-control/config/capacityJBOD.json /var/snap/charmed-kafka/current/etc/cruise-control
 
-# overriding defaults
+# overriding defaults and set up to use KRaft mode
 sudo sed -i -e 's/sample.store.topic.replication.factor=2/sample.store.topic.replication.factor=1/g' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
 sudo sed -i -e 's|capacity.config.file=config/capacityJBOD.json|capacity.config.file=/var/snap/charmed-kafka/current/etc/cruise-control/capacityJBOD.json|g' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
+
+sudo sed -i -e '/zookeeper.connect=localhost:2181\//c\# zookeeper.connect=localhost:2181/' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
+sudo sed -i -e '/zookeeper.security.enabled=false/c\# zookeeper.security.enabled=false' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
+sudo sed -i -e '/# zookeeper.security.enabled=false/a\kafka.broker.failure.detection.enable=true\n' /var/snap/charmed-kafka/current/etc/cruise-control/cruisecontrol.properties
 
 # starting services
 sudo snap start charmed-kafka.cruise-control

--- a/README.md
+++ b/README.md
@@ -12,18 +12,27 @@ To build locally, use `snapcraft --debug`
 Install the snap (e.g. `sudo snap install ./charmed-kafka_3.6.0_amd64.snap --dangerous --devmode`
 ).
 
-To run the snap, you will require a running Apache ZooKeeper service. You can use the following:
+To run the snap, you will require to set up a controller service and the Kafka service. You can use the following:
 
 ```bash
-# installing zookeeper
-sudo snap install charmed-zookeeper --channel 3/edge
-
 # copying default config
-sudo cp /snap/charmed-kafka/current/opt/kafka/config/server.properties /var/snap/charmed-kafka/current/etc/kafka/server.properties
-sudo cp /snap/charmed-zookeeper/current/opt/zookeeper/conf/zoo_sample.cfg /var/snap/charmed-zookeeper/current/etc/zookeeper/zoo.cfg
+sudo cp /snap/charmed-kafka/current/opt/kafka/config/broker.properties /var/snap/charmed-kafka/current/etc/kafka/server.properties
+sudo cp /snap/charmed-kafka/current/opt/kafka/config/controller.properties /var/snap/charmed-kafka/current/etc/kraft/controller.properties
+
+# setting up logging directories
+sudo sed -i '/log.dirs=/c\log.dirs=/var/snap/charmed-kafka/common/var/log/kafka' /var/snap/charmed-kafka/current/etc/kafka/server.properties
+sudo sed -i '/log.dirs=/c\log.dirs=/var/snap/charmed-kafka/common/var/log/kraft' /var/snap/charmed-kafka/current/etc/kraft/controller.properties
+
+# Creating cluster uuid and formatting controller and broker storage
+uuid=$(sudo charmed-kafka.storage random-uuid)
+sudo charmed-kafka.storage format --cluster-id $uuid -c /var/snap/charmed-kafka/current/etc/kafka/server.properties
+sudo charmed-kafka.storage format --standalone --cluster-id $uuid -c /var/snap/charmed-kafka/current/etc/kraft/controller.properties
+
+# snap runs as _daemon_ user, we make sure that the controller directory is owned by that user
+sudo chown -R _daemon_:_daemon_ /var/snap/charmed-kafka/common/var/log/kraft
 
 # starting services
-sudo snap start charmed-zookeeper.daemon
+sudo snap start charmed-kafka.controller
 sleep 5
 sudo snap start charmed-kafka.daemon
 ```
@@ -54,7 +63,7 @@ If you want to use custom log4j properties, place your custom log4j properties f
 
 ### Cruise Control
 
-To get started with Cruise Control, on a local system already running the Kafka and ZooKeeper services, you can use the following:
+To get started with Cruise Control, on a local system already running the Kafka service, you can use the following:
 
 ```bash
 # copying necessary configuration files

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 # Installation hook for charmed-kafka snap.
 #
-# Note: '584788' refers to the snap_daemon user and group within a snap,
+# Note: '584792' refers to the _daemon_ user and group within a snap,
 # exposed as user ID (UID) and group ID (GID).
-#
-# FIXME (24.04): From snapd 2.61 onwards, snap_daemon is being deprecated and
-# replaced with _daemon_ (with underscores), which now possesses a UID of 584792.
-# See https://snapcraft.io/docs/system-usernames.
 
 set -eux
 
@@ -23,12 +19,12 @@ do
     # setting dir permissions given re-attached storage
     if [stat -c '%u' "$DATA" == 0 -o ! -d "$DATA"]; then
         chmod -R 770 "${SNAP_COMMON}"
-        chown -R 584788:root "${SNAP_COMMON}"
+        chown -R 584792:root "${SNAP_COMMON}"
         chmod 750 "${DATA}"
-        chown 584788:root "${DATA}"
+        chown 584792:root "${DATA}"
     else
         chmod -R 770 "${LOGS}"
-        chown -R 584788:root "${LOGS}"
+        chown -R 584792:root "${LOGS}"
     fi
 
     # copying default config from squashfs
@@ -37,4 +33,4 @@ done
 
 # setting blanket permissions for the installing snap data dir
 chmod -R 770 "${SNAP_DATA}"/*
-chown -R 584788:root "${SNAP_DATA}"/*
+chown -R 584792:root "${SNAP_DATA}"/*

--- a/snap/local/etc/connect/log4j.properties
+++ b/snap/local/etc/connect/log4j.properties
@@ -50,9 +50,6 @@ log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 log4j.appender.authorizerAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
 log4j.appender.authorizerAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
-# Change the line below to adjust ZK client logging
-log4j.logger.org.apache.zookeeper=${charmed.kafka.log.level}
-
 # Change the two lines below to adjust the general broker logging level (output to server.log and stdout)
 log4j.logger.kafka=${charmed.kafka.log.level}
 log4j.logger.org.apache.kafka=${charmed.kafka.log.level}

--- a/snap/local/etc/kafka/log4j.properties
+++ b/snap/local/etc/kafka/log4j.properties
@@ -50,9 +50,6 @@ log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 log4j.appender.authorizerAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
 log4j.appender.authorizerAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
-# Change the line below to adjust ZK client logging
-log4j.logger.org.apache.zookeeper=${charmed.kafka.log.level}
-
 # Change the two lines below to adjust the general broker logging level (output to server.log and stdout)
 log4j.logger.kafka=${charmed.kafka.log.level}
 log4j.logger.org.apache.kafka=${charmed.kafka.log.level}

--- a/snap/local/etc/kraft/log4j.properties
+++ b/snap/local/etc/kraft/log4j.properties
@@ -56,9 +56,6 @@ log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 log4j.appender.authorizerAppender.MaxFileSize=${charmed.kafka.log.maxfilesize}
 log4j.appender.authorizerAppender.MaxBackupIndex=${charmed.kafka.log.retention}
 
-# Change the line below to adjust ZK client logging
-log4j.logger.org.apache.zookeeper=${charmed.kafka.log.level}
-
 # Change the two lines below to adjust the general broker logging level (output to server.log and stdout)
 log4j.logger.kafka=${charmed.kafka.log.level}
 log4j.logger.org.apache.kafka=${charmed.kafka.log.level}

--- a/snap/local/opt/cruise-control/bin/start-wrapper.bash
+++ b/snap/local/opt/cruise-control/bin/start-wrapper.bash
@@ -16,7 +16,7 @@ fi
 
 "${SNAP}"/usr/bin/setpriv \
     --clear-groups \
-    --reuid snap_daemon \
-    --regid snap_daemon -- \
+    --reuid _daemon_ \
+    --regid _daemon_ -- \
     "${SNAP}/opt/cruise-control/bin/kafka-cruise-control-start.sh" "${SNAP_DATA}"/etc/cruise-control/cruisecontrol.properties
 

--- a/snap/local/opt/kafka/bin/start-wrapper.bash
+++ b/snap/local/opt/kafka/bin/start-wrapper.bash
@@ -8,6 +8,6 @@ fi
 
 "${SNAP}"/usr/bin/setpriv \
     --clear-groups \
-    --reuid snap_daemon \
-    --regid snap_daemon -- \
+    --reuid _daemon_ \
+    --regid _daemon_ -- \
     "${SNAP}/opt/kafka/bin/kafka-server-start.sh" "${SNAP_DATA}"/etc/kafka/server.properties

--- a/snap/local/opt/kraft/bin/start-wrapper.bash
+++ b/snap/local/opt/kraft/bin/start-wrapper.bash
@@ -16,6 +16,6 @@ fi
 
 "${SNAP}"/usr/bin/setpriv \
     --clear-groups \
-    --reuid snap_daemon \
-    --regid snap_daemon -- \
+    --reuid _daemon_ \
+    --regid _daemon_ -- \
     "${SNAP}/opt/kafka/bin/kafka-server-start.sh" "${SNAP_DATA}"/etc/kraft/controller.properties

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,6 @@
 name: charmed-kafka
 base: core24
-# TODO update to 4.0
-version: '3.9.0'
+version: '4.0.0'
 summary: Apache Kafka in a snap.
 description: |
   This is a snap that bundles Apache Kafka together with other tools of its ecosystem in order to be used in Charmed Operators, providing automated operations management from day 0 to day 2 on the Apache Kafka real-time stream processing, on top of a Virtual Machine cluster and K8s cluster. It is an open source, end-to-end, production ready data platform on top of cloud native technologies.
@@ -322,9 +321,8 @@ parts:
 
   kafka:
     plugin: nil
-    # TODO: update to 4.0
-    source: https://github.com/canonical/central-uploader/releases/download/kafka_2.13-$SNAPCRAFT_PROJECT_VERSION-ubuntu1/kafka_2.13-$SNAPCRAFT_PROJECT_VERSION-ubuntu1-20241217045803.tgz
-    source-checksum: sha512/ae7552378eb542ce270b2f9e25856d7ad2202b20364b20c01a8fda16bcc3215c331720cc03e4c3fa4c7fb8c7580587cdfc4eb8ac37b4b218795c870fbc0c1cb3
+    source: https://github.com/canonical/central-uploader/releases/download/kafka_2.13-$SNAPCRAFT_PROJECT_VERSION-ubuntu1/kafka_2.13-$SNAPCRAFT_PROJECT_VERSION-ubuntu1-20250605135441.tgz
+    source-checksum: sha512/5b56b9f715caecadd43e34a76eb83e63e1fc185911ba485dc12a30f925d6427c40a42fc8dd94712ed3f5f30211d9c54869df6be74f4078033f3934471d5f6e32
     after: [cruise-control]
     build-packages:
     - ca-certificates-java

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,14 +1,18 @@
 name: charmed-kafka
-base: core22
-version: '3.9.1'
+base: core24
+# TODO update to 4.0
+version: '3.9.0'
 summary: Apache Kafka in a snap.
 description: |
   This is a snap that bundles Apache Kafka together with other tools of its ecosystem in order to be used in Charmed Operators, providing automated operations management from day 0 to day 2 on the Apache Kafka real-time stream processing, on top of a Virtual Machine cluster and K8s cluster. It is an open source, end-to-end, production ready data platform on top of cloud native technologies.
 grade: stable
 confinement: strict
 
+platforms:
+  amd64:
+
 system-usernames:
-  snap_daemon: shared
+  _daemon_: shared
 
 hooks:
   install:
@@ -318,7 +322,8 @@ parts:
 
   kafka:
     plugin: nil
-    source: https://github.com/canonical/central-uploader/releases/download/kafka_2.13-${SNAPCRAFT_PROJECT_VERSION}-ubuntu1/kafka_2.13-${SNAPCRAFT_PROJECT_VERSION}-ubuntu1-20241217045803.tgz
+    # TODO: update to 4.0
+    source: https://github.com/canonical/central-uploader/releases/download/kafka_2.13-$SNAPCRAFT_PROJECT_VERSION-ubuntu1/kafka_2.13-$SNAPCRAFT_PROJECT_VERSION-ubuntu1-20241217045803.tgz
     source-checksum: sha512/ae7552378eb542ce270b2f9e25856d7ad2202b20364b20c01a8fda16bcc3215c331720cc03e4c3fa4c7fb8c7580587cdfc4eb8ac37b4b218795c870fbc0c1cb3
     after: [cruise-control]
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ hooks:
       - mount-observe
 
 environment:
-  JAVA_HOME: $SNAP/usr/lib/jvm/java-18-openjdk-amd64
+  JAVA_HOME: $SNAP/usr/lib/jvm/java-21-openjdk-amd64
 
 slots:
   kafka-logs:
@@ -294,7 +294,7 @@ apps:
     environment:
       bin_script: connect-plugin-path.sh
   keytool:
-    command: usr/lib/jvm/java-18-openjdk-amd64/bin/keytool
+    command: usr/lib/jvm/java-21-openjdk-amd64/bin/keytool
     plugs:
       - mount-observe
 
@@ -329,7 +329,7 @@ parts:
     build-packages:
     - ca-certificates-java
     stage-packages:
-    - openjdk-18-jre-headless
+    - openjdk-21-jre-headless
     - util-linux
     - libpsl5
     - curl

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -178,14 +178,6 @@ apps:
       - mount-observe
     environment:
       bin_script: kafka-replica-verification.sh
-  zookeeper-shell:
-    command: opt/kafka/bin/bin-wrapper.bash
-    plugs:
-      - network
-      - network-bind
-      - mount-observe
-    environment:
-      bin_script: zookeeper-shell.sh
   run-class:
     command: opt/kafka/bin/bin-wrapper.bash
     plugs:


### PR DESCRIPTION
**Changes**
- Updates snap to use core24
- Switch system user to `_daemon_`
- Remove ZooKeeper from the tests and scripts
   - Cruise control: https://github.com/linkedin/cruise-control/wiki/Run-without-ZooKeeper 

**TODO**
- [x] Update artifact to Kafka 4.0 once released
- [ ] License information?