### PR TITLE
[DPE-8941] Release 4.1.1-ubuntu2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -296,8 +296,8 @@ parts:
 
   kafka:
     plugin: nil
-    source: https://github.com/canonical/central-uploader/releases/download/kafka_2.13-$SNAPCRAFT_PROJECT_VERSION-ubuntu1/kafka_2.13-$SNAPCRAFT_PROJECT_VERSION-ubuntu1-20251120134038.tgz
-    source-checksum: sha512/fee8ba4ebfb6417d8b72e2fb18112a214adac31ea6ab840c550ecf3739b49cc8604dd21fe87f41cd8de8a15314464b3200c0317dfda889cf88034a4777f859cc
+    source: https://github.com/canonical/central-uploader/releases/download/kafka_2.13-$SNAPCRAFT_PROJECT_VERSION-ubuntu2/kafka_2.13-$SNAPCRAFT_PROJECT_VERSION-ubuntu2-20251218143203.tgz
+    source-checksum: sha512/8f84929f8bba529929f22b29fddf7e0d82560a00e3af26e578acf6a78c14ff864bc6607294c63dd7a841a5cedeb0116f37969eec0c6dac51d89778d0e6371cc1
     after: [cruise-control]
     build-packages:
     - ca-certificates-java


### PR DESCRIPTION
fixes [CVE-2025-66566](https://nvd.nist.gov/vuln/detail/CVE-2025-66566)
