### PR TITLE
[DPE-10825] chore: adapt Python exporter for K8s env.

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -22,6 +22,7 @@ options:
   --bootstrap-server str
                         Comma-separated Kafka bootstrap servers list (required)
   --cycle float         Metric extraction cycle in seconds (default: 60.0)
+  --substrate {vm,k8s}  Workload substrate (default: vm)
 ```
 
 ## Sample exporter results:

--- a/prometheus/src/ckp/__init__.py
+++ b/prometheus/src/ckp/__init__.py
@@ -26,6 +26,7 @@ def iterate(config: Config):
             "--all-topics",
             "--describe",
         ],
+        substrate=config.SUBSTRATE,
     )
     parsed = parse_consumer_groups_output(raw)
     logger.debug(parsed)

--- a/prometheus/src/ckp/cli.py
+++ b/prometheus/src/ckp/cli.py
@@ -59,7 +59,7 @@ def run_bin_command(
     substrate: Substrates = "vm",
 ) -> str:
     """Execute a Kafka bin command."""
-    if os.environ.get("SNAP") and substrate != "k8s":
+    if os.environ.get("SNAP"):
         return _run_bin_command_in_snap(bin_keyword, bin_args, opts=opts)
 
     return _run_bin_command_on_substrate(bin_keyword, bin_args, opts=opts, substrate=substrate)

--- a/prometheus/src/ckp/cli.py
+++ b/prometheus/src/ckp/cli.py
@@ -3,7 +3,7 @@
 import os
 import subprocess
 
-from .core import Constants
+from .core import Constants, Substrates
 
 
 def execute(cmd, cwd: str | None = None, timeout: float = 10.0, env=None) -> str:
@@ -19,15 +19,23 @@ def execute(cmd, cwd: str | None = None, timeout: float = 10.0, env=None) -> str
     )
 
 
-def _run_bin_command_using_snap_app(
-    bin_keyword: str, bin_args: list[str], opts: list[str] | None = None
+def _run_bin_command_on_substrate(
+    bin_keyword: str,
+    bin_args: list[str],
+    opts: list[str] | None = None,
+    substrate: Substrates = "vm",
 ) -> str:
     """Execute a Kafka bin command using charmed-kafka apps."""
     if opts is None:
         opts = []
     opts_str = " ".join(opts)
     bin_str = " ".join(bin_args)
-    command = f"{opts_str} {Constants.SNAP}.{bin_keyword} {bin_str}"
+    cmd = (
+        f"{Constants.SNAP}.{bin_keyword}"
+        if substrate == "vm"
+        else f"/opt/kafka/bin/kafka-{bin_keyword}.sh"
+    )
+    command = f"{opts_str} {cmd} {bin_str}"
     return execute(command)
 
 
@@ -44,9 +52,14 @@ def _run_bin_command_in_snap(
     return execute(command, env=os.environ | {"bin_script": f"kafka-{bin_keyword}.sh"})
 
 
-def run_bin_command(bin_keyword: str, bin_args: list[str], opts: list[str] | None = None) -> str:
+def run_bin_command(
+    bin_keyword: str,
+    bin_args: list[str],
+    opts: list[str] | None = None,
+    substrate: Substrates = "vm",
+) -> str:
     """Execute a Kafka bin command."""
-    if os.environ.get("SNAP"):
+    if os.environ.get("SNAP") and substrate != "k8s":
         return _run_bin_command_in_snap(bin_keyword, bin_args, opts=opts)
 
-    return _run_bin_command_using_snap_app(bin_keyword, bin_args, opts=opts)
+    return _run_bin_command_on_substrate(bin_keyword, bin_args, opts=opts, substrate=substrate)

--- a/prometheus/src/ckp/core.py
+++ b/prometheus/src/ckp/core.py
@@ -1,10 +1,13 @@
 """Core models and data classes."""
 
+import typing
 from dataclasses import dataclass
 
 from prometheus_client import Gauge
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+Substrates = typing.Literal["vm", "k8s"]
 
 
 class Constants:
@@ -68,6 +71,7 @@ class Config(BaseSettings):
     )
     BOOTSTRAP_SERVER: str = Field(description="Comma-separated Kafka bootstrap servers list")
     CYCLE: float = Field(description="Metric extraction cycle in seconds", default=60.0)
+    SUBSTRATE: Substrates = Field(description="Workload substrate", default="vm")
 
     model_config = SettingsConfigDict(
         cli_parse_args=True,


### PR DESCRIPTION
Adds a `--substrate` CLI arg (and corresponding env. var) & adapt the metric extraction command for K8s environments accordingly.